### PR TITLE
Use proper spelling

### DIFF
--- a/res/langs/en.json
+++ b/res/langs/en.json
@@ -27,7 +27,7 @@
 	"login": "Login",
 	"exit": "Exit",
 	"settings": "Settings",
-	"synchThreshold": "Synch Threshold",
+	"synchThreshold": "Sync Threshold",
 	"general": "General",
 	"hotkeys": "Hotkeys",
 	"video": "Video",


### PR DESCRIPTION
The word "Synch" should be Sync, as this is the correct spelling in the English dictionary. I feel like commits like these may give a negative impression of intention, but I assure you I am in no way intending to offend anyone. I just want to help in any way I can since I love this project so much and wish to make it as good as possible. :) If you would like me to also change the variable names (or anything else with "Synch" in it, I would be happy to do so. 

Please continue to develop this amazing project as I do rely on it for recreation with out-of-state, friends and family. 

Cheers!