### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,7 @@
-FROM frolvlad/alpine-glibc
+FROM haxe:4.2.5-alpine3.15
 WORKDIR /usr/src/app
 
-RUN apk add nodejs npm git; \
-    npm install --global lix; \
-    lix install haxe 4.2.2 --global
+RUN apk add nodejs npm git
 
 COPY res ./res
 COPY src ./src


### PR DESCRIPTION
Hello,

It seems that building the docker using the old base image fail with this error:

``` => ERROR [10/10] RUN npm ci;     haxelib install all --always;     haxe build-all.hxml                                                                                                                                             2.8s
------
 > [10/10] RUN npm ci;     haxelib install all --always;     haxe build-all.hxml:
#15 1.325
#15 1.325 added 1 package, and audited 2 packages in 684ms
#15 1.328
#15 1.328 found 0 vulnerabilities
#15 1.470 Neko seems to be missing. Attempting download ...
#15 1.472 src/lix/client/haxe/Switcher.hx:326: x64
#15 2.530 -> Done!
#15 2.530 done
#15 2.537 Error relocating /root/haxe/neko/libneko.so.2: __pthread_register_cancel: symbol not found
#15 2.537 Error relocating /root/haxe/neko/libneko.so.2: __register_atfork: symbol not found
#15 2.537 Error relocating /root/haxe/neko/libneko.so.2: __pthread_unregister_cancel: symbol not found
#15 2.537 Error relocating /root/haxe/neko/libneko.so.2: __printf_chk: symbol not found
#15 2.537 Error relocating /root/haxe/neko/libneko.so.2: gnu_get_libc_version: symbol not found
#15 2.537 Error relocating /root/haxe/neko/libneko.so.2: __longjmp_chk: symbol not found
#15 2.537 Error relocating /root/haxe/neko/libneko.so.2: getcontext: symbol not found
#15 2.537 Error relocating /root/haxe/neko/libneko.so.2: __sprintf_chk: symbol not found
#15 2.537 Error relocating /lib/ld-linux-x86-64.so.2: unsupported relocation type 37
#15 2.537 Error relocating /root/haxe/versions/4.2.2/haxelib: __strdup: symbol not found
#15 2.537 Error relocating /root/haxe/versions/4.2.2/haxelib: __printf_chk: symbol not found
#15 2.537 Error relocating /root/haxe/versions/4.2.2/haxelib: __fprintf_chk: symbol not found
#15 2.537 Error relocating /root/haxe/versions/4.2.2/haxelib: __sprintf_chk: symbol not found
#15 2.712 haxelib path: Error relocating /root/haxe/neko/libneko.so.2: __pthread_register_cancel: symbol not found
#15 2.712 Error relocating /root/haxe/neko/libneko.so.2: __register_atfork: symbol not found
#15 2.712 Error relocating /root/haxe/neko/libneko.so.2: __pthread_unregister_cancel: symbol not found
#15 2.712 Error relocating /root/haxe/neko/libneko.so.2: __printf_chk: symbol not found
#15 2.712 Error relocating /root/haxe/neko/libneko.so.2: gnu_get_libc_version: symbol not found
#15 2.712 Error relocating /root/haxe/neko/libneko.so.2: __longjmp_chk: symbol not found
#15 2.712 Error relocating /root/haxe/neko/libneko.so.2: getcontext: symbol not found
#15 2.712 Error relocating /root/haxe/neko/libneko.so.2: __sprintf_chk: symbol not found
#15 2.712 Error relocating /lib/ld-linux-x86-64.so.2: unsupported relocation type 37
#15 2.712 Error relocating /root/haxe/versions/4.2.2/haxelib: __strdup: symbol not found
#15 2.712 Error relocating /root/haxe/versions/4.2.2/haxelib: __printf_chk: symbol not found
#15 2.712 Error relocating /root/haxe/versions/4.2.2/haxelib: __fprintf_chk: symbol not found
#15 2.712 Error relocating /root/haxe/versions/4.2.2/haxelib: __sprintf_chk: symbol not found
#15 2.712
```

Rebasing the project on `haxe:4.2.5-alpine3.15` image allow me to build the container successfully.
