### PR TITLE
Ignore video limit per user for admins

### DIFF
--- a/build/server.js
+++ b/build/server.js
@@ -4363,7 +4363,7 @@ server_Main.prototype = {
 				this.serverMessage(client,"totalVideoLimitError");
 				return;
 			}
-			if(this.config.userVideoLimit != 0 && this.videoList.itemsByUser(client) >= this.config.userVideoLimit) {
+			if(this.config.userVideoLimit != 0 && ((client.group & 8) == 0) && this.videoList.itemsByUser(client) >= this.config.userVideoLimit) {
 				this.serverMessage(client,"videoLimitPerUserError");
 				return;
 			}

--- a/src/server/Main.hx
+++ b/src/server/Main.hx
@@ -586,7 +586,7 @@ class Main {
 					serverMessage(client, "totalVideoLimitError");
 					return;
 				}
-				if (config.userVideoLimit != 0
+				if (config.userVideoLimit != 0 && !client.isAdmin
 					&& videoList.itemsByUser(client) >= config.userVideoLimit) {
 					serverMessage(client, "videoLimitPerUserError");
 					return;


### PR DESCRIPTION
When you restoring a previously cleared playlist as an admin, the videoLimitPerUserError prevents you from adding more items then specified for a regular user. This change adds ignoring the check for admins. 