### PR TITLE
Add docker-compose (further simplify docker setup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,14 @@ Default channel example: https://synctube.onrender.com/
 - Open showed "Local" link for yourself and send "Global" link to friends
 
 ### Setup (Docker)
-- As alternative, you can install Docker and run:
-- `docker build -t synctube .`
-- `docker run --rm -it -p 4200:4200 -v ${PWD}/user:/usr/src/app/user synctube`
+As alternative, you can install Docker and run:
+> - `docker build -t synctube .`
+> - `docker run --rm -it -p 4200:4200 -v ${PWD}/user:/usr/src/app/user synctube`
+
+or 
+
+> - `docker compose up -d`
+
 - (Docker container hides real local/global ips, so you need to checkout it manually)
 
 ### Configuration

--- a/README.md
+++ b/README.md
@@ -29,12 +29,16 @@ Default channel example: https://synctube.onrender.com/
 
 ### Setup (Docker)
 As alternative, you can install Docker and run:
-> - `docker build -t synctube .`
-> - `docker run --rm -it -p 4200:4200 -v ${PWD}/user:/usr/src/app/user synctube`
+> ```shell
+> docker build -t synctube .
+> docker run --rm -it -p 4200:4200 -v ${PWD}/user:/usr/src/app/user synctube
+> ```
 
 or 
 
-> - `docker compose up -d`
+> ```shell
+> docker compose up -d
+> ```
 
 - (Docker container hides real local/global ips, so you need to checkout it manually)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+# Run this as follows: 'docker compose up'  (keep running in terminal session, exist via [STRG] + [C]) 
+#                   or 'docker compose up -d' (keep running in background)
+version: "3"
+services:
+  synctube:
+     build: .
+    #image: synctube
+     ports:
+       - "4200:4200"
+     volumes:
+       - "${PWD}/user:/usr/src/app/user"


### PR DESCRIPTION
Summary:
- Add `docker-compose.yaml` file
- Update `README.md`

This adds a docker-compose file to the project, enabling to run it simply via `docker-compose up -d` instead of the previously used two line command. 
This is also added to the README.md file to inform  users about the new option. 